### PR TITLE
Fix Android Locale issue with rounding location attribute floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-## [Unreleased]
+## [1.4.0]
+- [Fixed] Locale issue when rounding location float attributes (eg: `speed`, `heading`, `odometer`)
 - [Added] `removeListeners` method for removing all event-listeners.
 - [Added] Ability to provide optional arbitrary meta-data `extras` on geofences.
 - [Changed] Location parameters `heading`, `accuracy`, `odometer`, `speed`, `altitude`, `altitudeAccuracy` are now fixed at 2 decimal places.

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,11 +12,11 @@
       "ios": "2.0.0",
       "android": "2.0.0"
     },
-    "tns-ios": {
-      "version": "2.4.0"
-    },
     "tns-android": {
       "version": "2.4.1"
+    },
+    "tns-ios": {
+      "version": "2.4.0"
     }
   },
   "dependencies": {
@@ -24,7 +24,7 @@
     "nativescript-background-geolocation-lt": "file:..",
     "nativescript-fonticon": "^1.1.0",
     "nativescript-google-maps-sdk": "^1.3.13",
-    "tns-core-modules": "2.4.2",
+    "tns-core-modules": "2.4.4",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "homepage": "http://shop.transistorsoft.com/pages/nativescript-background-geolocation",
   "devDependencies": {
-    "tns-platform-declarations": "^2.4.1",
-    "tns-core-modules": "^2.4.1",
+    "tns-platform-declarations": "^2.4.2",
+    "tns-core-modules": "^2.4.4",
     "typescript": "^2.0.3"
   },
   "dependencies": {


### PR DESCRIPTION
- [Fixed] Locale issue when rounding location float attributes (eg: `speed`, `heading`, `odometer`)