### PR TITLE
Accepting variable googlePlayServicesLocationVersion as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ Add the following to the file **`references.d.ts`** in the root of your applicat
 
 #### Google Play Services
 
-Since this plugin uses Google Play Services, it's very common to have Android build conflicts with *other* plugins using Play Services / Android support libraries (eg: `com.android.support:appcompat-v7`).  The key to solving build issues is to ensure that *all* plugins are aligned to the same play-services version (eg: `15.0.1`) and support-library versions (eg: `26.1.0`).  **Note**:  Firebase dependencies must also be aligned to the same play-services version).
+Since this plugin uses Google Play Services Location, it's very common to have Android build conflicts with *other* plugins using Play Services Location (`com.google.android.gms:play-services-location`) / Android Support libraries (`com.android.support:appcompat-v7`). The key to solving build issues is to ensure that *all* plugins are aligned to the same play-services-location version (eg: `16.0.0`) and support-library versions (eg: `26.1.0`).
 
-You can specify your desired `play-services` version in the file:
+You can specify your desired `play-services-location` version in the file:
 **`app/App_Resources/Android/app.gradle`**
 
 ```gradle
 project.ext {
-  googlePlayServicesVersion = "11.8.0"
+  googlePlayServicesLocationVersion = "16.0.0"
   supportVersion = "27.0.1"
 }
 ```

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -2,9 +2,14 @@
 dependencies {
   def DEFAULT_PLAY_SERVICES_VERSION   = "11.8.0"
   def DEFAULT_SUPPORT_LIB_VERSION     = "27.0.1"
-
-  def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_PLAY_SERVICES_VERSION
   def supportLibVersion = DEFAULT_SUPPORT_LIB_VERSION
+  def googlePlayServicesLocationVersion = DEFAULT_PLAY_SERVICES_VERSION
+
+  if (project.hasProperty('googlePlayServicesLocationVersion')){
+    googlePlayServicesLocationVersion = project.googlePlayServicesLocationVersion
+  } else if (project.hasProperty('googlePlayServicesVersion')){
+    googlePlayServicesLocationVersion = project.googlePlayServicesVersion
+  }
 
   if (project.hasProperty('supportLibVersion')) {
     supportLibVersion = project.supportLibVersion
@@ -14,11 +19,11 @@ dependencies {
 
   println "******************************************************************"
   println "* nativescript-background-geolocation"
-  println "* - googlePlayServicesVersion: $googlePlayServicesVersion"
+  println "* - googlePlayServicesLocationVersion: $googlePlayServicesLocationVersion"
   println "* - supportLibVersion: $supportLibVersion"  
   println "******************************************************************"
   
-  compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
+  compile "com.google.android.gms:play-services-location:$googlePlayServicesLocationVersion"
   compile "com.android.support:appcompat-v7:$supportLibVersion"
   compile 'com.squareup.okhttp3:okhttp:3.10.0'
   compile 'org.greenrobot:eventbus:3.0.0'


### PR DESCRIPTION
As can be found here https://developers.google.com/android/guides/releases
Since May 2, 2018 Google Play services libraries have independent versions number.

I've changed the code to allow us to set the version number only for the com.google.android.gms:play-services-location library and don't conflict with other plugins that use the same variable name (googlePlayServicesVersion) to set the google play service versions.

The code will still allow you to use googlePlayServicesVersion though.